### PR TITLE
feat: add restore button

### DIFF
--- a/src/components/WindowsControl/index.tsx
+++ b/src/components/WindowsControl/index.tsx
@@ -16,6 +16,7 @@ interface Props {
   onMouseDown?: (e: React.MouseEvent<HTMLDivElement>) => void;
   style?: any;
   disabled?: boolean;
+  isMaximized?: boolean;
 }
 
 interface State {
@@ -37,7 +38,7 @@ export class WindowsControl extends React.PureComponent<Props, State> {
 
   public render() {
     const { hover } = this.state;
-    const { close, maximize, minimize, restore, whiteIcon, onClick, style, disabled } = this.props;
+    const { close, maximize, minimize, restore, whiteIcon, onClick, style, disabled, isMaximized } = this.props;
 
     let icon: string;
 
@@ -63,6 +64,7 @@ export class WindowsControl extends React.PureComponent<Props, State> {
               : '#e81123'
             : 'transparent',
           pointerEvents: disabled ? 'none' : 'auto',
+          display: isMaximized ? 'none' : 'auto'
           ...style,
         }}
       >

--- a/src/components/WindowsControl/index.tsx
+++ b/src/components/WindowsControl/index.tsx
@@ -16,7 +16,6 @@ interface Props {
   onMouseDown?: (e: React.MouseEvent<HTMLDivElement>) => void;
   style?: any;
   disabled?: boolean;
-  isMaximized?: boolean;
 }
 
 interface State {
@@ -64,7 +63,6 @@ export class WindowsControl extends React.PureComponent<Props, State> {
               : '#e81123'
             : 'transparent',
           pointerEvents: disabled ? 'none' : 'auto',
-          display: isMaximized ? 'none' : 'auto'
           ...style,
         }}
       >

--- a/src/components/WindowsControl/index.tsx
+++ b/src/components/WindowsControl/index.tsx
@@ -16,6 +16,7 @@ interface Props {
   onMouseDown?: (e: React.MouseEvent<HTMLDivElement>) => void;
   style?: any;
   disabled?: boolean;
+  restore?: boolean;
 }
 
 interface State {
@@ -42,9 +43,14 @@ export class WindowsControl extends React.PureComponent<Props, State> {
     let icon: string;
 
     if (close) icon = closeIcon;
-    else if (maximize) icon = maximizeIcon;
     else if (minimize) icon = minimizeIcon;
-    else if (restore) icon = restoreIcon;
+    
+    if(maximize == true) {
+        icon = maximizeIcon
+    }
+    if(restore == true) {
+        icon = restoreIcon
+    }
 
     return (
       <div

--- a/src/components/WindowsControl/index.tsx
+++ b/src/components/WindowsControl/index.tsx
@@ -3,11 +3,13 @@ import * as React from 'react';
 import closeIcon from '../../icons/close.svg';
 import maximizeIcon from '../../icons/maximize.svg';
 import minimizeIcon from '../../icons/minimize.svg';
+import restoreIcon from '../../icons/restore.svg';
 
 interface Props {
   maximize?: boolean;
   close?: boolean;
   minimize?: boolean;
+  restore?: boolean;
   whiteIcon?: boolean;
   onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
   onMouseUp?: (e: React.MouseEvent<HTMLDivElement>) => void;
@@ -35,13 +37,14 @@ export class WindowsControl extends React.PureComponent<Props, State> {
 
   public render() {
     const { hover } = this.state;
-    const { close, maximize, minimize, whiteIcon, onClick, style, disabled } = this.props;
+    const { close, maximize, minimize, restore, whiteIcon, onClick, style, disabled } = this.props;
 
     let icon: string;
 
     if (close) icon = closeIcon;
     else if (maximize) icon = maximizeIcon;
     else if (minimize) icon = minimizeIcon;
+    else if (restore) icon = restoreIcon;
 
     return (
       <div

--- a/src/components/WindowsControls/index.tsx
+++ b/src/components/WindowsControls/index.tsx
@@ -25,8 +25,8 @@ export const WindowsControls = ({
   return (
     <div onMouseUp={onMouseUp} style={{ display: 'flex', ...style }}>
       <WindowsControl minimize whiteIcon={dark} onClick={onMinimize} />
-      <WindowsControl maximize isMaximized={isMaximized == true} whiteIcon={dark} onClick={onMaximize} />
-      <WindowsControl restore isMaximized={isMaximized == false} whiteIcon={dark} onClick={onMaximize} />
+      <WindowsControl maximize isMaximized={isMaximized == false} whiteIcon={dark} onClick={onMaximize} />
+      <WindowsControl restore isMaximized={isMaximized == true} whiteIcon={dark} onClick={onMaximize} />
       <WindowsControl close whiteIcon={dark} onClick={onClose} />
     </div>
   );

--- a/src/components/WindowsControls/index.tsx
+++ b/src/components/WindowsControls/index.tsx
@@ -10,6 +10,7 @@ interface Props {
   onMouseDown?: (e: React.MouseEvent<HTMLDivElement>) => void;
   style?: any;
   isMaximized?: boolean;
+  isRestor?: boolean;
 }
 
 export const WindowsControls = ({
@@ -24,8 +25,8 @@ export const WindowsControls = ({
   return (
     <div onMouseUp={onMouseUp} style={{ display: 'flex', ...style }}>
       <WindowsControl minimize whiteIcon={dark} onClick={onMinimize} />
-      <WindowsControl maximize isMaximized={isMaximized} whiteIcon={dark} onClick={onMaximize} />
-      <WindowsControl restore isMaximized={isMaximized} whiteIcon={dark} onClick={onMaximize} />
+      <WindowsControl maximize isMaximized={isMaximized == true} whiteIcon={dark} onClick={onMaximize} />
+      <WindowsControl restore isMaximized={isMaximized == false} whiteIcon={dark} onClick={onMaximize} />
       <WindowsControl close whiteIcon={dark} onClick={onClose} />
     </div>
   );

--- a/src/components/WindowsControls/index.tsx
+++ b/src/components/WindowsControls/index.tsx
@@ -9,6 +9,7 @@ interface Props {
   onMouseUp?: (e: React.MouseEvent<HTMLDivElement>) => void;
   onMouseDown?: (e: React.MouseEvent<HTMLDivElement>) => void;
   style?: any;
+  isMaximized?: boolean;
 }
 
 export const WindowsControls = ({
@@ -18,11 +19,13 @@ export const WindowsControls = ({
   onMinimize,
   onMouseUp,
   style,
+  isMaximized,
 }: Props) => {
   return (
     <div onMouseUp={onMouseUp} style={{ display: 'flex', ...style }}>
       <WindowsControl minimize whiteIcon={dark} onClick={onMinimize} />
-      <WindowsControl maximize whiteIcon={dark} onClick={onMaximize} />
+      <WindowsControl maximize isMaximized={isMaximized} whiteIcon={dark} onClick={onMaximize} />
+      <WindowsControl restore isMaximized={isMaximized} whiteIcon={dark} onClick={onMaximize} />
       <WindowsControl close whiteIcon={dark} onClick={onClose} />
     </div>
   );

--- a/src/components/WindowsControls/index.tsx
+++ b/src/components/WindowsControls/index.tsx
@@ -10,7 +10,6 @@ interface Props {
   onMouseDown?: (e: React.MouseEvent<HTMLDivElement>) => void;
   style?: any;
   isMaximized?: boolean;
-  isRestor?: boolean;
 }
 
 export const WindowsControls = ({

--- a/src/components/WindowsControls/index.tsx
+++ b/src/components/WindowsControls/index.tsx
@@ -9,7 +9,6 @@ interface Props {
   onMouseUp?: (e: React.MouseEvent<HTMLDivElement>) => void;
   onMouseDown?: (e: React.MouseEvent<HTMLDivElement>) => void;
   style?: any;
-  isMaximized?: boolean;
 }
 
 export const WindowsControls = ({
@@ -24,8 +23,7 @@ export const WindowsControls = ({
   return (
     <div onMouseUp={onMouseUp} style={{ display: 'flex', ...style }}>
       <WindowsControl minimize whiteIcon={dark} onClick={onMinimize} />
-      <WindowsControl maximize isMaximized={isMaximized == false} whiteIcon={dark} onClick={onMaximize} />
-      <WindowsControl restore isMaximized={isMaximized == true} whiteIcon={dark} onClick={onMaximize} />
+      <WindowsControl maximize={!isMaximized} restore={isMaximized} whiteIcon={dark} onClick={onMaximize} />
       <WindowsControl close whiteIcon={dark} onClick={onClose} />
     </div>
   );

--- a/src/icons/restore.svg
+++ b/src/icons/restore.svg
@@ -1,0 +1,1 @@
+<svg width='11' height='11' viewBox='0 0 11 11' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M11 8.798H8.798V11H0V2.202h2.202V0H11v8.798zm-3.298-5.5h-6.6v6.6h6.6v-6.6zM9.9 1.1H3.298v1.101h5.5v5.5h1.1v-6.6z' fill='#000'/></svg>


### PR DESCRIPTION
I added the restore button because it was missing when the window is maximized.

```
<WindowsControls isMaximized={remote.getCurrentWindow().isMaximized}>

</WindowsControls>
```

If `remote.getCurrentWindow().isMaximized` is true, the restore button will be shown, if false, the maximise button will be shown.